### PR TITLE
remove testnet graphql endpoint until indexer ready.

### DIFF
--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -25,11 +25,11 @@ export function getGraphqlURI(networkName: NetworkName): string | undefined {
         import.meta.env.MAINNET_GRAPHQL ||
         `https://${prefix}aptos.movementlabs.xyz/graphql`
       );
-    case "testnet":
-      return (
-        import.meta.env.TESTNET_GRAPHQL ||
-        `https://${prefix}aptos.testnet.suzuka.movementlabs.xyz/graphql`
-      );
+    // case "testnet":
+    //   return (
+    //     import.meta.env.TESTNET_GRAPHQL ||
+    //     `https://${prefix}aptos.testnet.suzuka.movementlabs.xyz/graphql`
+    //   );
     case "devnet":
       return (
         import.meta.env.DEVNET_GRAPHQL ||


### PR DESCRIPTION
Hey @0xPrimata - I have a small adjustment here.  Until the indexer is ready, i have hidden the testnet graphql endpoint.  This will ensure pages that rely on graphql dont return blank content 

**Testing**
If you click transactions it now displays all transactions by default, not the blank user tx page.

