### PR TITLE
Homepage transactions display update

### DIFF
--- a/src/pages/LandingPage/TransactionsPreview.tsx
+++ b/src/pages/LandingPage/TransactionsPreview.tsx
@@ -23,10 +23,14 @@ function TransactionContent({data}: UseQueryResult<Array<Types.Transaction>>) {
 
 export default function TransactionsPreview() {
   const [state] = useGlobalState();
-  const limit = PREVIEW_LIMIT;
+  const limit = 35;
   const result = useQuery({
     queryKey: ["transactions", {limit}, state.network_value],
     queryFn: () => getTransactions({limit}, state.aptos_client),
+    select: (data) =>
+      data
+        .filter((tx) => tx.type === "user_transaction")
+        .slice(0, PREVIEW_LIMIT),
   });
   const augmentTo = useAugmentToWithGlobalSearchParams();
 


### PR DESCRIPTION
#Description

Only show user transactions on the homepage.  Increase limit when getting transactions from rpc to ensure we have enough user_transaction after filtering out other types.