### PR TITLE
fix(NetwworkSelect): go to home page when choose network

### DIFF
--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -17,6 +17,7 @@ import {
 import {NetworkName, networks} from "../../constants";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {grey} from "../../themes/colors/aptosColorPalette";
+import {useNavigate} from "../../routing";
 
 interface CustomParams {
   restUrl: string;
@@ -108,19 +109,22 @@ export default function NetworkSelect() {
   const [restUrl, setRestUrl] = React.useState("");
   // eslint-disable-next-line
   const [graphqlUrl, setGraphqlUrl] = React.useState("");
+  const navigate = useNavigate(); // Custom navigation hook
 
   const handleChange = (event: SelectChangeEvent<string>) => {
-    if (event.target.value == "custom") {
+    const selectedNetwork = event.target.value;
+
+    if (selectedNetwork === "custom") {
       if (
         verifyUrl(customParameters.restUrl) &&
         verifyUrl(customParameters.graphqlUrl)
       ) {
-        const network_name = event.target.value;
-        selectNetwork(network_name as NetworkName);
+        selectNetwork(selectedNetwork as NetworkName);
+        navigate(`/?network=custom`);
       }
     } else {
-      const network_name = event.target.value;
-      selectNetwork(network_name as NetworkName);
+      selectNetwork(selectedNetwork as NetworkName);
+      navigate(`/?network=${encodeURIComponent(selectedNetwork)}`);
     }
   };
 


### PR DESCRIPTION
# go to Home page with selection of network.

![image](https://github.com/user-attachments/assets/1f34c6fb-45a7-4dda-b7e7-0582460bdd6a)

**issue:**

- when you are in any pages of inside the network like exploring transaction and you changed the network then it will be empty so, better redirect to home page.
![image](https://github.com/user-attachments/assets/32beba9d-c3f4-4c81-b9ab-d193e5fd343f)


