### PR TITLE
Address link fix

### DIFF
--- a/src/pages/Transaction/Tabs/Components/TransactionActions.tsx
+++ b/src/pages/Transaction/Tabs/Components/TransactionActions.tsx
@@ -9,7 +9,9 @@ const AddressLink: React.FC<{
   address: string;
   type: "address" | "object" | "token";
 }> = ({address, type}) => (
-  <Link to={`/${type}/${AccountAddress.from(address).toString()}`}>
+  <Link
+    to={`/${type === "address" ? "account" : type}/${AccountAddress.from(address).toString()}`}
+  >
     {truncateAddress(address)}
   </Link>
 );


### PR DESCRIPTION
On the transaction detail page, fix the address links so they map to /account not /address (Under transactions actions).