### PR TITLE
Asset icon fix

### DIFF
--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -282,7 +282,9 @@ export function findCoinData(
         tryStandardizeAddress(faAddress) === tryStandardizeAddress(c.faAddress);
       const isMatchingCoin =
         coinType && c.tokenAddress && c.tokenAddress === coinType;
-      return isMatchingCoin || isMatchingFa;
+      const isMatchingFullCoinType =
+        asset_type && c.tokenAddress && c.tokenAddress === asset_type;
+      return isMatchingCoin || isMatchingFa || isMatchingFullCoinType;
     });
   }
   return entry;


### PR DESCRIPTION
### Description

When viewing the MOVE coin type, the logo was not displaying.  This ensures the coinData function also matches the hardcoded coin data. 

For testing, visit /txn/23641479/balanceChange?network=mainnet and should see the move icon properly idsplay (on the live explorer it does not https://explorer.movementnetwork.xyz/txn/23641479/balanceChange?network=mainnet