### PR TITLE
Redirect ?network=testnet to ?network=bardock+testnet

### DIFF
--- a/src/global-config/GlobalConfig.tsx
+++ b/src/global-config/GlobalConfig.tsx
@@ -1,7 +1,7 @@
-import { Aptos, AptosConfig, NetworkToNetworkName } from "@aptos-labs/ts-sdk";
-import { AptosClient, IndexerClient } from "aptos";
-import React, { useMemo, useState } from "react";
-import { getGraphqlURI } from "../api/hooks/useGraphqlClient";
+import {Aptos, AptosConfig, NetworkToNetworkName} from "@aptos-labs/ts-sdk";
+import {AptosClient, IndexerClient} from "aptos";
+import React, {useMemo, useState} from "react";
+import {getGraphqlURI} from "../api/hooks/useGraphqlClient";
 import {
   FeatureName,
   NetworkName,
@@ -13,7 +13,7 @@ import {
   getSelectedFeatureFromLocalStorage,
   useFeatureSelector,
 } from "./feature-selection";
-import { useNetworkSelector } from "./network-selection";
+import {useNetworkSelector} from "./network-selection";
 
 const HEADERS = {
   "x-indexer-client": "movement-explorer",
@@ -54,13 +54,14 @@ function deriveGlobalState({
 
   // If network has no URL, fallback to mainnet to prevent crashes
   const safeNetworkName = networkUrl === "" ? defaultNetworkName : network_name;
-  const safeNetworkUrl = networkUrl === "" ? networks[defaultNetworkName] : networkUrl;
+  const safeNetworkUrl =
+    networkUrl === "" ? networks[defaultNetworkName] : networkUrl;
 
   const indexerUri = getGraphqlURI(safeNetworkName);
   const apiKey = getApiKey(safeNetworkName);
   let indexerClient = undefined;
   if (indexerUri) {
-    indexerClient = new IndexerClient(indexerUri, { HEADERS, TOKEN: apiKey });
+    indexerClient = new IndexerClient(indexerUri, {HEADERS, TOKEN: apiKey});
   }
   return {
     feature_name,
@@ -137,4 +138,4 @@ export const useGlobalState = () =>
     React.useContext(GlobalActionsContext),
   ] as const;
 
-export const getCustomParameters = () => { };
+export const getCustomParameters = () => {};

--- a/src/global-config/network-selection.ts
+++ b/src/global-config/network-selection.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import {useEffect} from "react";
+import {useSearchParams} from "react-router-dom";
 import {
   NetworkName,
   defaultNetworkName,
@@ -45,7 +45,7 @@ export function useNetworkSelector() {
 
   function selectNetwork(
     network: NetworkName,
-    { replace = false }: { replace?: boolean } = {},
+    {replace = false}: {replace?: boolean} = {},
   ) {
     if (!isValidNetworkName(network)) return;
     setSearchParams(
@@ -54,7 +54,7 @@ export function useNetworkSelector() {
         newParams.set("network", network);
         return newParams;
       },
-      { replace },
+      {replace},
     );
     writeSelectedNetworkToLocalStorage(network);
   }
@@ -66,13 +66,16 @@ export function useNetworkSelector() {
 
       // Redirect testnet to bardock testnet (testnet is valid but has no URL)
       if (currentNetworkSearchParam === "testnet") {
-        selectNetwork("bardock testnet", { replace: true });
+        selectNetwork("bardock testnet", {replace: true});
         return;
       }
 
       // Check if network is valid AND has a URL (not empty)
-      if (!isValidNetworkName(currentNetworkSearchParam ?? "") ||
-        (currentNetworkSearchParam && networks[currentNetworkSearchParam as NetworkName] === "")) {
+      if (
+        !isValidNetworkName(currentNetworkSearchParam ?? "") ||
+        (currentNetworkSearchParam &&
+          networks[currentNetworkSearchParam as NetworkName] === "")
+      ) {
         selectNetwork(defaultNetworkName, {
           replace: true,
         });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,16 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
 import React from "react";
-import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import {createRoot} from "react-dom/client";
+import {BrowserRouter} from "react-router-dom";
 import ExplorerRoutes from "./ExplorerRoutes";
 
 // import * as Sentry from "@sentry/react";
 // import {BrowserTracing} from "@sentry/tracing";
 
-import { AptosClient } from "aptos";
+import {AptosClient} from "aptos";
 import ReactGA from "react-ga4";
-import { initGTM } from "./api/hooks/useGoogleTagManager";
-import { GTMEvents } from "./dataConstants";
+import {initGTM} from "./api/hooks/useGoogleTagManager";
+import {GTMEvents} from "./dataConstants";
 
 initGTM({
   events: {
@@ -45,12 +45,11 @@ ReactGA.initialize(import.meta.env.GA_TRACKING_ID || "G-VS7KJG61TM");
 // inform the compiler of the existence of the window.aptos API
 declare global {
   interface Window {
-    aptos: AptosClient
+    aptos: AptosClient;
   }
 }
 
 const queryClient = new QueryClient();
-
 
 const container = document.getElementById("root");
 const root = createRoot(container!);


### PR DESCRIPTION
### Description

Redirect explorer links ending in ?network=testnet to ?network=bardock+testnet:

- Added client-side redirect from ?network=testnet to ?network=bardock+testnet in useNetworkSelector
- Added fallback redirect for invalid networks to ?network=mainnet
- Added safety check in deriveGlobalState to prevent crashes when network has empty URL

### Related Links

<!-- Please link to any relevant issues or pull requests! -->

### Checklist
