### PR TITLE
[Feat] Integrate Bytecode Verification Status Display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 # IDEs and editors
 /.idea
 /.vscode
+/.claude
+/.cursor
+/.taskmaster
 
 # misc
 .DS_Store

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -43,9 +43,9 @@ export interface ModuleVerificationStatusResponse {
   verified: boolean;
 }
 
-/** Fetch module verification status. 
+/** Fetch module verification status for a specific contract version (upgrade_number).
  * Throws:
- * - NOT_FOUND (404) - no source code available
+ * - NOT_FOUND (404) - no source code available, or contract upgraded (refresh page)
  * - SERVICE_UNAVAILABLE (503) - verification disabled on node
  * - COMPILATION_ERROR (422) - cannot verify (e.g., unsupported dependencies)
  */
@@ -53,9 +53,11 @@ export async function getModuleVerificationStatus(
   nodeUrl: string,
   address: string,
   moduleName: string,
+  upgradeNumber?: number,
 ): Promise<ModuleVerificationStatusResponse> {
-  const url = `${nodeUrl}/v1/accounts/${address}/modules/${moduleName}/verification_status`;
-  
+  const params = upgradeNumber != null ? `?upgrade_number=${upgradeNumber}` : "";
+  const url = `${nodeUrl}/v1/accounts/${address}/modules/${moduleName}/verification_status${params}`;
+
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,6 +4,7 @@ export enum ResponseErrorType {
   UNHANDLED = "Unhandled",
   TOO_MANY_REQUESTS = "Too Many Requests",
   SERVICE_UNAVAILABLE = "Service Unavailable",
+  COMPILATION_ERROR = "Compilation Error",
 }
 
 export type ResponseError = {type: ResponseErrorType; message?: string};
@@ -42,7 +43,12 @@ export interface ModuleVerificationStatusResponse {
   verified: boolean;
 }
 
-/** Fetch module verification status. Throws NOT_FOUND (404) or SERVICE_UNAVAILABLE (503). */
+/** Fetch module verification status. 
+ * Throws:
+ * - NOT_FOUND (404) - no source code available
+ * - SERVICE_UNAVAILABLE (503) - verification disabled on node
+ * - COMPILATION_ERROR (422) - cannot verify (e.g., unsupported dependencies)
+ */
 export async function getModuleVerificationStatus(
   nodeUrl: string,
   address: string,
@@ -60,6 +66,11 @@ export async function getModuleVerificationStatus(
   if (!response.ok) {
     if (response.status === 404) {
       throw {type: ResponseErrorType.NOT_FOUND};
+    }
+    if (response.status === 422) {
+      // Compilation error - can't verify, but not suspicious
+      const errorData = await response.json().catch(() => ({}));
+      throw {type: ResponseErrorType.COMPILATION_ERROR, message: errorData.message};
     }
     if (response.status === 503) {
       throw {type: ResponseErrorType.SERVICE_UNAVAILABLE};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,7 @@ export enum ResponseErrorType {
   INVALID_INPUT = "Invalid Input",
   UNHANDLED = "Unhandled",
   TOO_MANY_REQUESTS = "Too Many Requests",
+  SERVICE_UNAVAILABLE = "Service Unavailable",
 }
 
 export type ResponseError = {type: ResponseErrorType; message?: string};
@@ -15,6 +16,9 @@ export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
       error = error as Response;
       if (error.status === 404) {
         throw {type: ResponseErrorType.NOT_FOUND};
+      }
+      if (error.status === 503) {
+        throw {type: ResponseErrorType.SERVICE_UNAVAILABLE};
       }
     }
     if (
@@ -32,4 +36,39 @@ export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
       message: error.toString(),
     };
   });
+}
+
+export interface ModuleVerificationStatusResponse {
+  verified: boolean;
+}
+
+/** Fetch module verification status. Throws NOT_FOUND (404) or SERVICE_UNAVAILABLE (503). */
+export async function getModuleVerificationStatus(
+  nodeUrl: string,
+  address: string,
+  moduleName: string,
+): Promise<ModuleVerificationStatusResponse> {
+  const url = `${nodeUrl}/v1/accounts/${address}/modules/${moduleName}/verification_status`;
+  
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw {type: ResponseErrorType.NOT_FOUND};
+    }
+    if (response.status === 503) {
+      throw {type: ResponseErrorType.SERVICE_UNAVAILABLE};
+    }
+    throw {
+      type: ResponseErrorType.UNHANDLED,
+      message: `HTTP error! status: ${response.status}`,
+    };
+  }
+
+  return await response.json();
 }

--- a/src/api/hooks/useGetModuleVerificationStatus.ts
+++ b/src/api/hooks/useGetModuleVerificationStatus.ts
@@ -1,0 +1,40 @@
+import {useQuery, UseQueryResult} from "@tanstack/react-query";
+import {
+  getModuleVerificationStatus,
+  ModuleVerificationStatusResponse,
+  ResponseError,
+  ResponseErrorType,
+} from "../client";
+import {useGlobalState} from "../../global-config/GlobalConfig";
+
+/** Hook to query module bytecode verification status. */
+export function useGetModuleVerificationStatus(
+  address: string,
+  moduleName: string,
+  options?: {enabled?: boolean},
+): UseQueryResult<ModuleVerificationStatusResponse, ResponseError> {
+  const [state] = useGlobalState();
+
+  return useQuery<ModuleVerificationStatusResponse, ResponseError>({
+    queryKey: [
+      "moduleVerificationStatus",
+      {address, moduleName},
+      state.network_value,
+    ],
+    queryFn: () =>
+      getModuleVerificationStatus(state.network_value, address, moduleName),
+    refetchOnWindowFocus: false,
+    retry: (failureCount, error) => {
+      // Don't retry for expected error types
+      if (
+        error.type === ResponseErrorType.NOT_FOUND ||
+        error.type === ResponseErrorType.SERVICE_UNAVAILABLE
+      ) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+    ...options,
+  });
+}
+

--- a/src/api/hooks/useGetModuleVerificationStatus.ts
+++ b/src/api/hooks/useGetModuleVerificationStatus.ts
@@ -28,7 +28,8 @@ export function useGetModuleVerificationStatus(
       // Don't retry for expected error types
       if (
         error.type === ResponseErrorType.NOT_FOUND ||
-        error.type === ResponseErrorType.SERVICE_UNAVAILABLE
+        error.type === ResponseErrorType.SERVICE_UNAVAILABLE ||
+        error.type === ResponseErrorType.COMPILATION_ERROR
       ) {
         return false;
       }

--- a/src/api/hooks/useGetModuleVerificationStatus.ts
+++ b/src/api/hooks/useGetModuleVerificationStatus.ts
@@ -7,22 +7,28 @@ import {
 } from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 
-/** Hook to query module bytecode verification status. */
+/** Hook to query module bytecode verification status for a contract version (upgrade_number). */
 export function useGetModuleVerificationStatus(
   address: string,
   moduleName: string,
-  options?: {enabled?: boolean},
+  options?: {enabled?: boolean; upgradeNumber?: number},
 ): UseQueryResult<ModuleVerificationStatusResponse, ResponseError> {
   const [state] = useGlobalState();
+  const {upgradeNumber, ...rest} = options ?? {};
 
   return useQuery<ModuleVerificationStatusResponse, ResponseError>({
     queryKey: [
       "moduleVerificationStatus",
-      {address, moduleName},
+      {address, moduleName, upgradeNumber},
       state.network_value,
     ],
     queryFn: () =>
-      getModuleVerificationStatus(state.network_value, address, moduleName),
+      getModuleVerificationStatus(
+        state.network_value,
+        address,
+        moduleName,
+        upgradeNumber,
+      ),
     refetchOnWindowFocus: false,
     retry: (failureCount, error) => {
       // Don't retry for expected error types
@@ -35,7 +41,7 @@ export function useGetModuleVerificationStatus(
       }
       return failureCount < 2;
     },
-    ...options,
+    ...rest,
   });
 }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -13,15 +13,15 @@ export const bardockTestnetUrl =
   import.meta.env.MOVEMENT_TESTNET_URL ||
   `https://testnet.movementnetwork.xyz/v1`;
 
-  export const networks = {
-    mainnet: mainnetUrl,
-    testnet: "",
-    "bardock testnet": bardockTestnetUrl,
+export const networks = {
+  mainnet: mainnetUrl,
+  testnet: "",
+  "bardock testnet": bardockTestnetUrl,
   devnet: "",
-    local: "http://127.0.0.1:8080",
-    mevmdevnet: "",
-    custom: "",
-  };
+  local: "http://127.0.0.1:8080",
+  mevmdevnet: "",
+  custom: "",
+};
 
 export const availableNetworks = ["mainnet", "bardock testnet"];
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -18,7 +18,7 @@ export const bardockTestnetUrl =
     testnet: "",
     "bardock testnet": bardockTestnetUrl,
   devnet: "",
-    local: "http://localhost:30731",
+    local: "http://127.0.0.1:8080",
     mevmdevnet: "",
     custom: "",
   };

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -247,6 +247,11 @@ export function Code({
         </Box>
       ) : shouldShowCode ? (
         <Stack spacing={1}>
+          {isVerified && (
+            <Alert severity="success">
+              Source code verified: the displayed code matches the deployed bytecode.
+            </Alert>
+          )}
           {hasVerificationFailure && (
             <Alert severity="error">
               The deployer provided source code but it does not match the deployed bytecode. The displayed code may not accurately represent what is actually running on-chain.

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -173,6 +173,7 @@ export function Code({
   const hasVerificationFailure = verificationStatus?.verified === false;
   const hasVerificationDisabled = verificationError?.type === ResponseErrorType.SERVICE_UNAVAILABLE;
   const hasVerificationUnavailable = verificationError?.type === ResponseErrorType.NOT_FOUND;
+  const hasCompilationError = verificationError?.type === ResponseErrorType.COMPILATION_ERROR;
   const shouldShowCode = !!sourceCode;
 
   return (
@@ -247,12 +248,17 @@ export function Code({
       ) : shouldShowCode ? (
         <Stack spacing={1}>
           {hasVerificationFailure && (
-            <Alert severity="warning">
+            <Alert severity="error">
               The deployer provided source code but it does not match the deployed bytecode. The displayed code may not accurately represent what is actually running on-chain.
             </Alert>
           )}
-          {(hasVerificationDisabled || hasVerificationUnavailable) && (
+          {hasCompilationError && (
             <Alert severity="warning">
+              This contract cannot be verified because it uses dependencies that are not part of the standard Aptos framework. The displayed code was provided by the deployer and may not match the deployed bytecode.
+            </Alert>
+          )}
+          {(hasVerificationDisabled || hasVerificationUnavailable) && (
+            <Alert severity="info">
               Source code verification is not available on this node. The displayed code was provided by the deployer and may not match the deployed bytecode.
             </Alert>
           )}

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -1,4 +1,12 @@
-import {Box, Button, Modal, Stack, Typography, useTheme} from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Modal,
+  Stack,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import {ContentCopy, OpenInFull} from "@mui/icons-material";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import {getPublicFunctionLineNumber, transformCode} from "../../../utils";
@@ -18,6 +26,8 @@ import {
 } from "../../../themes/colors/aptosColorPalette";
 import {useParams} from "react-router-dom";
 import {useLogEventWithBasic} from "../hooks/useLogEventWithBasic";
+import {useGetModuleVerificationStatus} from "../../../api/hooks/useGetModuleVerificationStatus";
+import {ResponseErrorType} from "../../../api/client";
 
 function useStartingLineNumber(sourceCode?: string) {
   const functionToHighlight = useParams().selectedFnName;
@@ -105,15 +115,36 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
   );
 }
 
-export function Code({bytecode}: {bytecode: string}) {
+/** Displays source code only if bytecode verification succeeds. */
+export function Code({
+  bytecode,
+  address,
+  moduleName,
+}: {
+  bytecode: string;
+  address?: string;
+  moduleName?: string;
+}) {
   const {selectedModuleName} = useParams();
   const logEvent = useLogEventWithBasic();
+  const theme = useTheme();
+
+  // Use the module name from props or from URL params
+  const moduleNameToVerify = moduleName || selectedModuleName || "";
+
+  // Query verification status
+  const {
+    data: verificationStatus,
+    isLoading: isVerificationLoading,
+    error: verificationError,
+  } = useGetModuleVerificationStatus(address || "", moduleNameToVerify, {
+    enabled: !!address && !!moduleNameToVerify,
+  });
 
   const TOOLTIP_TIME = 2000; // 2s
 
   const sourceCode = bytecode === "0x" ? undefined : transformCode(bytecode);
 
-  const theme = useTheme();
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
 
   async function copyCode() {
@@ -136,6 +167,36 @@ export function Code({bytecode}: {bytecode: string}) {
     }
   });
 
+  // Check if code should be shown:
+  // - If verification is disabled (SERVICE_UNAVAILABLE) or loading, don't show code
+  // - If verified = true, show code
+  // - If verified = false or NOT_FOUND, don't show code
+  const isVerified = verificationStatus?.verified === true;
+  const shouldShowCode = sourceCode && isVerified;
+
+  // Determine the message to show when code is not displayed
+  const getNoCodeMessage = () => {
+    if (isVerificationLoading) {
+      return null; // Will show loading spinner
+    }
+    if (verificationError) {
+      if (verificationError.type === ResponseErrorType.SERVICE_UNAVAILABLE) {
+        return "Source code is not available because verification is not enabled on this node.";
+      }
+      if (verificationError.type === ResponseErrorType.NOT_FOUND) {
+        return "Source code is not available.";
+      }
+      return "Unable to verify source code.";
+    }
+    if (!sourceCode) {
+      return "Unfortunately, the source code cannot be shown because the package publisher has chosen not to make it available.";
+    }
+    if (verificationStatus?.verified === false) {
+      return "Source code is not available because it does not match the deployed bytecode.";
+    }
+    return "Source code is not available.";
+  };
+
   return (
     <Box>
       <Stack
@@ -154,9 +215,8 @@ export function Code({bytecode}: {bytecode: string}) {
           <Typography fontSize={20} fontWeight={700}>
             Code
           </Typography>
-          <StyledLearnMoreTooltip text="Please be aware that this code was provided by the owner and it could be different to the real code on blockchain. We cannot verify it." />
         </Stack>
-        {sourceCode && (
+        {shouldShowCode && (
           <Stack direction="row" spacing={2}>
             <StyledTooltip
               title="Code copied"
@@ -196,24 +256,17 @@ export function Code({bytecode}: {bytecode: string}) {
           </Stack>
         )}
       </Stack>
-      {sourceCode && (
-        <Typography
-          variant="body1"
-          fontSize={14}
-          fontWeight={400}
-          marginBottom={"16px"}
-          color={theme.palette.mode === "dark" ? grey[400] : grey[600]}
+      {isVerificationLoading ? (
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          padding={4}
         >
-          The source code is plain text uploaded by the deployer, which can be
-          different from the actual bytecode.
-        </Typography>
-      )}
-      {!sourceCode ? (
-        <Box>
-          Unfortunately, the source code cannot be shown because the package
-          publisher has chosen not to make it available
+          <CircularProgress size={24} />
+          <Typography marginLeft={2}>Verifying source code...</Typography>
         </Box>
-      ) : (
+      ) : shouldShowCode ? (
         <Box
           sx={{
             maxHeight: "100vh",
@@ -234,6 +287,13 @@ export function Code({bytecode}: {bytecode: string}) {
           >
             {sourceCode}
           </SyntaxHighlighter>
+        </Box>
+      ) : (
+        <Box
+          padding={2}
+          bgcolor={theme.palette.mode === "dark" ? grey[800] : grey[100]}
+        >
+          <Typography color={grey[500]}>{getNoCodeMessage()}</Typography>
         </Box>
       )}
     </Box>

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -168,37 +168,12 @@ export function Code({
     }
   });
 
-  // Check if code should be shown:
-  // - Show code if sourceCode exists (unless SERVICE_UNAVAILABLE or NOT_FOUND)
-  // - Show warning if verified = false
+  // Always show code if sourceCode exists, with warnings when appropriate
   const isVerified = verificationStatus?.verified === true;
   const hasVerificationFailure = verificationStatus?.verified === false;
-  const shouldShowCode = sourceCode && 
-    verificationError?.type !== ResponseErrorType.SERVICE_UNAVAILABLE &&
-    verificationError?.type !== ResponseErrorType.NOT_FOUND;
-
-  // Determine the message to show when code is not displayed
-  const getNoCodeMessage = () => {
-    if (isVerificationLoading) {
-      return null; // Will show loading spinner
-    }
-    if (verificationError) {
-      if (verificationError.type === ResponseErrorType.SERVICE_UNAVAILABLE) {
-        return "Source code is not available because verification is not enabled on this node.";
-      }
-      if (verificationError.type === ResponseErrorType.NOT_FOUND) {
-        return "Source code is not available.";
-      }
-      return "Unable to verify source code.";
-    }
-    if (!sourceCode) {
-      return "Unfortunately, the source code cannot be shown because the package publisher has chosen not to make it available.";
-    }
-    if (verificationStatus?.verified === false) {
-      return "Source code is not available because it does not match the deployed bytecode.";
-    }
-    return "Source code is not available.";
-  };
+  const hasVerificationDisabled = verificationError?.type === ResponseErrorType.SERVICE_UNAVAILABLE;
+  const hasVerificationUnavailable = verificationError?.type === ResponseErrorType.NOT_FOUND;
+  const shouldShowCode = !!sourceCode;
 
   return (
     <Box>
@@ -219,7 +194,7 @@ export function Code({
             Code
           </Typography>
         </Stack>
-        {shouldShowCode && (
+        {sourceCode && (
           <Stack direction="row" spacing={2}>
             <StyledTooltip
               title="Code copied"
@@ -276,6 +251,11 @@ export function Code({
               The deployer provided source code but it does not match the deployed bytecode. The displayed code may not accurately represent what is actually running on-chain.
             </Alert>
           )}
+          {(hasVerificationDisabled || hasVerificationUnavailable) && (
+            <Alert severity="warning">
+              Source code verification is not available on this node. The displayed code was provided by the deployer and may not match the deployed bytecode.
+            </Alert>
+          )}
           <Box
             sx={{
               maxHeight: "100vh",
@@ -303,7 +283,9 @@ export function Code({
           padding={2}
           bgcolor={theme.palette.mode === "dark" ? grey[800] : grey[100]}
         >
-          <Typography color={grey[500]}>{getNoCodeMessage()}</Typography>
+          <Typography color={grey[500]}>
+            The source code cannot be shown because the package publisher has chosen not to make it available.
+          </Typography>
         </Box>
       )}
     </Box>

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -121,10 +121,12 @@ export function Code({
   bytecode,
   address,
   moduleName,
+  upgradeNumber,
 }: {
   bytecode: string;
   address?: string;
   moduleName?: string;
+  upgradeNumber?: number;
 }) {
   const {selectedModuleName} = useParams();
   const logEvent = useLogEventWithBasic();
@@ -133,13 +135,14 @@ export function Code({
   // Use the module name from props or from URL params
   const moduleNameToVerify = moduleName || selectedModuleName || "";
 
-  // Query verification status
+  // Query verification for this contract version (upgrade_number)
   const {
     data: verificationStatus,
     isLoading: isVerificationLoading,
     error: verificationError,
   } = useGetModuleVerificationStatus(address || "", moduleNameToVerify, {
     enabled: !!address && !!moduleNameToVerify,
+    upgradeNumber,
   });
 
   const TOOLTIP_TIME = 2000; // 2s

--- a/src/pages/Account/Components/CodeSnippet.tsx
+++ b/src/pages/Account/Components/CodeSnippet.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -115,7 +116,7 @@ function ExpandCode({sourceCode}: {sourceCode: string | undefined}) {
   );
 }
 
-/** Displays source code only if bytecode verification succeeds. */
+/** Displays source code with a warning if bytecode verification fails. */
 export function Code({
   bytecode,
   address,
@@ -168,11 +169,13 @@ export function Code({
   });
 
   // Check if code should be shown:
-  // - If verification is disabled (SERVICE_UNAVAILABLE) or loading, don't show code
-  // - If verified = true, show code
-  // - If verified = false or NOT_FOUND, don't show code
+  // - Show code if sourceCode exists (unless SERVICE_UNAVAILABLE or NOT_FOUND)
+  // - Show warning if verified = false
   const isVerified = verificationStatus?.verified === true;
-  const shouldShowCode = sourceCode && isVerified;
+  const hasVerificationFailure = verificationStatus?.verified === false;
+  const shouldShowCode = sourceCode && 
+    verificationError?.type !== ResponseErrorType.SERVICE_UNAVAILABLE &&
+    verificationError?.type !== ResponseErrorType.NOT_FOUND;
 
   // Determine the message to show when code is not displayed
   const getNoCodeMessage = () => {
@@ -267,27 +270,34 @@ export function Code({
           <Typography marginLeft={2}>Verifying source code...</Typography>
         </Box>
       ) : shouldShowCode ? (
-        <Box
-          sx={{
-            maxHeight: "100vh",
-            overflow: "auto",
-            borderRadius: 0,
-            backgroundColor: codeBlockColor,
-          }}
-          ref={codeBoxScrollRef}
-        >
-          <SyntaxHighlighter
-            language="rust"
-            key={theme.palette.mode}
-            style={
-              theme.palette.mode === "light" ? solarizedLight : solarizedDark
-            }
-            customStyle={{margin: 0, backgroundColor: "unset"}}
-            showLineNumbers
+        <Stack spacing={1}>
+          {hasVerificationFailure && (
+            <Alert severity="warning">
+              The deployer provided source code but it does not match the deployed bytecode. The displayed code may not accurately represent what is actually running on-chain.
+            </Alert>
+          )}
+          <Box
+            sx={{
+              maxHeight: "100vh",
+              overflow: "auto",
+              borderRadius: 0,
+              backgroundColor: codeBlockColor,
+            }}
+            ref={codeBoxScrollRef}
           >
-            {sourceCode}
-          </SyntaxHighlighter>
-        </Box>
+            <SyntaxHighlighter
+              language="rust"
+              key={theme.palette.mode}
+              style={
+                theme.palette.mode === "light" ? solarizedLight : solarizedDark
+              }
+              customStyle={{margin: 0, backgroundColor: "unset"}}
+              showLineNumbers
+            >
+              {sourceCode}
+            </SyntaxHighlighter>
+          </Box>
+        </Stack>
       ) : (
         <Box
           padding={2}

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -158,7 +158,11 @@ function Contract({
           {module && fn && selectedModule && (
             <>
               <Divider sx={{margin: "24px 0"}} />
-              <Code bytecode={selectedModule?.source} />
+              <Code
+                bytecode={selectedModule?.source}
+                address={address}
+                moduleName={selectedModuleName}
+              />
             </>
           )}
         </Box>

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -72,6 +72,11 @@ function Contract({
   const {data, isLoading, error} = useGetAccountModules(address);
   const {selectedModuleName, selectedFnName} = useParams();
   const sortedPackages: PackageMetadata[] = useGetAccountPackages(address);
+  const selectedPackage = sortedPackages.find((p) =>
+    p.modules.some((m) => m.name === selectedModuleName),
+  );
+  const upgradeNumber =
+    selectedPackage != null ? Number(selectedPackage.upgrade_number) : undefined;
   const selectedModule = sortedPackages
     .flatMap((pkg) => pkg.modules)
     .find((module) => module.name === selectedModuleName);
@@ -162,6 +167,7 @@ function Contract({
                 bytecode={selectedModule?.source}
                 address={address}
                 moduleName={selectedModuleName}
+                upgradeNumber={upgradeNumber}
               />
             </>
           )}

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -39,14 +39,20 @@ interface ModuleContentProps {
   address: string;
   moduleName: string;
   bytecode: string;
+  upgradeNumber?: number;
 }
 
 function ViewCode({address, isObject}: {address: string; isObject: boolean}) {
   const sortedPackages: PackageMetadata[] = useGetAccountPackages(address);
-
   const navigate = useNavigate();
-
   const selectedModuleName = useParams().selectedModuleName ?? "";
+
+  const selectedPackage = sortedPackages.find((p) =>
+    p.modules.some((m) => m.name === selectedModuleName),
+  );
+  const upgradeNumber =
+    selectedPackage != null ? Number(selectedPackage.upgrade_number) : undefined;
+
   useEffect(() => {
     if (
       !selectedModuleName &&
@@ -98,6 +104,7 @@ function ViewCode({address, isObject}: {address: string; isObject: boolean}) {
             address={address}
             moduleName={selectedModuleName}
             bytecode={selectedModule.source}
+            upgradeNumber={upgradeNumber}
           />
         )}
       </Grid2>
@@ -179,7 +186,12 @@ function ModuleSidebar({
   );
 }
 
-function ModuleContent({address, moduleName, bytecode}: ModuleContentProps) {
+function ModuleContent({
+  address,
+  moduleName,
+  bytecode,
+  upgradeNumber,
+}: ModuleContentProps) {
   const theme = useTheme();
   return (
     <Stack
@@ -191,7 +203,12 @@ function ModuleContent({address, moduleName, bytecode}: ModuleContentProps) {
     >
       <ModuleHeader address={address} moduleName={moduleName} />
       <Divider />
-      <Code bytecode={bytecode} address={address} moduleName={moduleName} />
+      <Code
+        bytecode={bytecode}
+        address={address}
+        moduleName={moduleName}
+        upgradeNumber={upgradeNumber}
+      />
       <Divider />
       <ABI address={address} moduleName={moduleName} />
     </Stack>

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -191,7 +191,7 @@ function ModuleContent({address, moduleName, bytecode}: ModuleContentProps) {
     >
       <ModuleHeader address={address} moduleName={moduleName} />
       <Divider />
-      <Code bytecode={bytecode} />
+      <Code bytecode={bytecode} address={address} moduleName={moduleName} />
       <Divider />
       <ABI address={address} moduleName={moduleName} />
     </Stack>


### PR DESCRIPTION
# Integrate Bytecode Verification Status Display

**Target Branch:** `main`

## Related Issues

Closes https://github.com/movementlabsxyz/explorer/issues/114

## Dependencies

Depends on https://github.com/movementlabsxyz/aptos-core/pull/272

## Summary

This PR integrates the new bytecode verification API endpoint into the explorer UI. The explorer now queries the node's verification status and displays source code with appropriate warnings. Source code is always shown (if available), with warnings displayed when verification fails, is disabled, or unavailable.

## Changes

### Core Features

- **Verification Status Query**: New React hook `useGetModuleVerificationStatus` to query node verification status
- **Conditional Display**: Source code is always displayed (if available), with warnings shown based on verification status:
  - Shows code normally if `verified: true` (matching source/bytecode) ✓
  - Shows code with **error** alert if `verified: false` (SUSPICIOUS - bytecode mismatch)
  - Shows code with **warning** alert if HTTP 422 (can't verify due to unsupported dependencies)
  - Shows code with **info** alert if verification is disabled (HTTP 503) or unavailable (HTTP 404)
- **User Feedback**: Clear warnings with appropriate severity levels:
  - Loading state: "Verifying source code..."
  - **Error (red)** - Mismatch: "The deployer provided source code but it does not match the deployed bytecode..."
  - **Warning (yellow)** - Can't verify: "This contract cannot be verified because it uses dependencies that are not part of the standard Aptos framework..."
  - **Info (blue)** - Disabled/Unavailable: "Source code verification is not available on this node..."

### Implementation Details

1. **API Client** (`src/api/client.ts`):
   - Added `SERVICE_UNAVAILABLE` and `COMPILATION_ERROR` error types
   - Added `getModuleVerificationStatus` function
   - Added `ModuleVerificationStatusResponse` interface
   - Updated error handling to catch HTTP 503 and HTTP 422

2. **React Hook** (`src/api/hooks/useGetModuleVerificationStatus.ts`): New file
   - React Query hook for fetching verification status
   - Proper error handling and retry logic
   - Skips retry for expected errors (404, 422, 503)

3. **Code Display Component** (`src/pages/Account/Components/CodeSnippet.tsx`):
   - Added verification status query
   - Always displays source code if available (maintains previous behavior)
   - Shows alerts with appropriate severity:
     - **Error**: Verification fails (`verified: false`) - mismatched source/bytecode (SUSPICIOUS)
     - **Warning**: Compilation error (HTTP 422) - can't verify, uses unsupported dependencies
     - **Info**: Verification disabled (HTTP 503) or unavailable (HTTP 404)
   - Loading state during verification
   - Removed old disclaimer about unverified code

4. **Module Views**:
   - `src/pages/Account/Tabs/ModulesTab/ViewCode.tsx`: Passes address and moduleName to Code component
   - `src/pages/Account/Tabs/ModulesTab/Contract.tsx`: Passes address and moduleName to Code component

5. **Constants** (`src/constants.tsx`):
   - Updated local network URL to standard port 8080

## Testing

Manual testing was performed using the test setup at [analysis-explorer-vulnerability](https://github.com/movementlabsxyz/analysis-explorer-vulnerability) on local devnet:

| Scenario | Expected Behavior |
|----------|-------------------|
| Matching source code | Displays code without warning ✓ |
| Mismatched source code | Displays code with **error** alert (red) |
| Unsupported dependencies (HTTP 422) | Displays code with **warning** alert (yellow) |
| Verification disabled (HTTP 503) | Displays code with **info** alert (blue) |
| No source code (HTTP 404) | Displays code with **info** alert (blue) |
