### PR TITLE
chore(security): add 14-day minimum release age and pin pnpm 10.33.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
 auto-install-peers=true
 strict-peer-dependencies=false
 package-manager-strict=false
+
+# Cooldown: block installs until a version has been published this long (minutes).
+# pnpm 10.16+ and npm 11.10+. 20160 = 14 days (org-wide default).
+minimum-release-age=20160

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "homepage": "./",
-  "packageManager": "pnpm@10.2.0",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "type": "module",
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary

Adds a **14-day minimum release age** for registry installs and bumps **pnpm to 10.33.0** so that setting is supported in CI (e.g. Vercel) and locally.

Delay installing freshly published versions so obvious malicious or broken releases are more likely to be yanked or flagged before we pull them. pnpm 9 did not support this option; pnpm 10.16+ does.

## Changes

- **`.npmrc`** — `minimum-release-age=20160` (14 days in minutes; pnpm 10.16+).
- **`package.json`** — `packageManager` set to **pnpm@10.33.0** (with tarball integrity) so installs respect `minimum-release-age` on supported pnpm versions.

## Hotfix escape hatch

Temporarily remove or zero `minimum-release-age` in `.npmrc` on a branch, merge the dependency fix, then restore **20160** in a follow-up (or use pnpm’s `minimumReleaseAgeExclude` for a narrow exception).

## Testing:

- [ ] `corepack enable` (or use repo `packageManager`), `pnpm --version` → **10.33.x**
- [ ] `pnpm install` succeeds on `main` lockfile
- [ ] Locally run `pnpm add axios@1.15.1` (or any version published &lt; 14 days ago) → expect **`ERR_PNPM_NO_MATURE_MATCHING_VERSION`**; revert any test edits to `package.json` / lockfile
- [ ] Confirm Vercel (or CI) build uses **pnpm 10** and passes with committed `.npmrc`

## Notes
- Reqauires `ENABLE_EXPERIMENTAL_COREPACK=1` env var in Vercel to force pnpm version.