### PR TITLE
Fix Coin holders tab crashing to black screen

### DIFF
--- a/src/api/hooks/useGetCoinHolders.ts
+++ b/src/api/hooks/useGetCoinHolders.ts
@@ -3,7 +3,7 @@ import {ApolloError, gql} from "@apollo/client";
 
 export type CoinHolder = {
   owner_address: string;
-  amount_v2: number;
+  amount: number | string | null;
 };
 
 export function useGetCoinHolders(
@@ -20,13 +20,13 @@ export function useGetCoinHolders(
     gql`
       query GetFungibleAssetBalances($coin_type: String!, $offset: Int!) {
         current_fungible_asset_balances(
-          where: {asset_type: {_eq: $coin_type}}
+          where: {asset_type: {_eq: $coin_type}, amount: {_is_null: false}}
           limit: 100
           offset: $offset
-          order_by: {amount_v2: desc}
+          order_by: {amount: desc_nulls_last}
         ) {
           owner_address
-          amount_v2
+          amount
         }
       }
     `,
@@ -36,6 +36,8 @@ export function useGetCoinHolders(
   return {
     isLoading: loading,
     error,
-    data: data?.current_fungible_asset_balances,
+    data: data?.current_fungible_asset_balances?.filter(
+      (h) => h.amount !== null && h.amount !== undefined,
+    ),
   };
 }

--- a/src/pages/Coin/Tabs/HoldersTab.tsx
+++ b/src/pages/Coin/Tabs/HoldersTab.tsx
@@ -52,7 +52,7 @@ export function HoldersTable({
       <GeneralTableBody>
         {holders.map((holder, i) => {
           return (
-            <GeneralTableRow>
+            <GeneralTableRow key={`${i}-${holder.owner_address}`}>
               <GeneralTableCell>{i}</GeneralTableCell>
               <GeneralTableCell>
                 <HashButton
@@ -62,7 +62,7 @@ export function HoldersTable({
               </GeneralTableCell>
               <GeneralTableCell align={"right"}>
                 {getFormattedBalanceStr(
-                  holder.amount_v2.toString(),
+                  (holder.amount ?? 0).toString(),
                   data.data.decimals,
                 ) +
                   " " +

--- a/src/pages/FungibleAsset/Tabs/HoldersTab.tsx
+++ b/src/pages/FungibleAsset/Tabs/HoldersTab.tsx
@@ -52,7 +52,7 @@ export function HoldersTable({
       <GeneralTableBody>
         {holders.map((holder, i) => {
           return (
-            <GeneralTableRow>
+            <GeneralTableRow key={`${i}-${holder.owner_address}`}>
               <GeneralTableCell>{i}</GeneralTableCell>
               <GeneralTableCell>
                 <HashButton
@@ -62,7 +62,7 @@ export function HoldersTable({
               </GeneralTableCell>
               <GeneralTableCell align={"right"}>
                 {getFormattedBalanceStr(
-                  holder.amount_v2.toString(),
+                  (holder.amount ?? 0).toString(),
                   data.coinData?.decimals ?? data.metadata?.decimals,
                 ) +
                   " " +


### PR DESCRIPTION
## Summary

The Beta - Holders tab on coin pages (e.g. `/coin/0x1::aptos_coin::AptosCoin/holders`) was crashing the entire React tree, leaving a black screen and a non-functional back button.

## Root cause

The GraphQL query in `useGetCoinHolders` ordered by `amount_v2: desc`. In Postgres, `ORDER BY ... DESC` puts NULLs **first**. The Movement indexer stores many coin-form holder rows with `amount_v2 = null` (the value lives in the combined `amount` column instead), so the top 100 rows returned were all nulls.

`HoldersTab.tsx` then called `holder.amount_v2.toString()` on a null value, which threw `Cannot read properties of null` and unmounted the page.

This is not an indexer bug — the data is present in `amount`; we were querying the wrong column with the wrong ordering.

## Changes

- `src/api/hooks/useGetCoinHolders.ts`
  - Query the combined `amount` field instead of `amount_v2`.
  - Add `where: {amount: {_is_null: false}}` and `order_by: {amount: desc_nulls_last}`.
  - Filter any remaining null rows client-side as a defensive belt.
  - Update type to `amount: number | string | null`.
- `src/pages/Coin/Tabs/HoldersTab.tsx`
  - Null-coerce `holder.amount` before `.toString()`.
  - Add missing `key` prop on the table row.

## Test plan

- [ ] Visit `/coin/0x1::aptos_coin::AptosCoin/holders?network=mainnet` — page renders top holders with real balances, no black screen.
- [ ] Back button returns to the coin page.
- [ ] Other coins' holders tabs still render correctly.
- [ ] Beta - Transactions tab unchanged.
