### PR TITLE
Fix: Mainnet Beta -> Mainnet, Bardock Testnet -> Testnet, remove Porto

### DIFF
--- a/src/api/hooks/useGetAnalyticsData.ts
+++ b/src/api/hooks/useGetAnalyticsData.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from "react";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 
-export const BARDOCK_ANALYTICS_DATA_URL =
+export const TESTNET_ANALYTICS_DATA_URL =
   "https://storage.googleapis.com/explorer_stats/chain_stats_testnet_v2.json";
 
 export const ANALYTICS_DATA_URL =
@@ -101,8 +101,7 @@ export function useGetAnalyticsData() {
 
   useEffect(() => {
     const options = {
-      "bardock testnet": BARDOCK_ANALYTICS_DATA_URL,
-      testnet: null,
+      testnet: TESTNET_ANALYTICS_DATA_URL,
       mainnet: ANALYTICS_DATA_URL,
       devnet: null,
       local: null,

--- a/src/api/hooks/useGetTPS.ts
+++ b/src/api/hooks/useGetTPS.ts
@@ -6,7 +6,7 @@ import {useGetTPSByBlockHeight} from "./useGetTPSByBlockHeight";
 import {
   AnalyticsData,
   ANALYTICS_DATA_URL,
-  BARDOCK_ANALYTICS_DATA_URL,
+  TESTNET_ANALYTICS_DATA_URL,
 } from "./useGetAnalyticsData";
 import {availableNetworks} from "../../constants";
 
@@ -41,8 +41,8 @@ export function useGetPeakTPS() {
       const fetchData = async () => {
         let ANALYTICS_DATA_URL_USE;
         switch (state.network_name) {
-          case "bardock testnet":
-            ANALYTICS_DATA_URL_USE = BARDOCK_ANALYTICS_DATA_URL;
+          case "testnet":
+            ANALYTICS_DATA_URL_USE = TESTNET_ANALYTICS_DATA_URL;
             break;
           default:
             ANALYTICS_DATA_URL_USE = ANALYTICS_DATA_URL;

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -20,14 +20,9 @@ export function getGraphqlURI(networkName: NetworkName): string | undefined {
   switch (networkName) {
     case "mainnet":
       return `https://indexer.mainnet.movementnetwork.xyz/v1/graphql`;
-    // case "testnet":
-    //   return (
-    //     import.meta.env.PORTO_GRAPHQL ||
-    //     `https://indexer.testnet.porto.movementnetwork.xyz/v1/graphql`
-    //   );
-    case "bardock testnet":
+    case "testnet":
       return (
-        import.meta.env.BARDOCK_GRAPHQL ||
+        import.meta.env.TESTNET_GRAPHQL ||
         `https://hasura.testnet.movementnetwork.xyz/v1/graphql`
       );
     // case "devnet":

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -13,15 +13,14 @@ export const testnetUrl =
   import.meta.env.MOVEMENT_TESTNET_URL ||
   `https://testnet.movementnetwork.xyz/v1`;
 
-  export const networks = {
-    mainnet: mainnetUrl,
-    testnet: "",
-    "testnet": testnetUrl,
+export const networks = {
+  mainnet: mainnetUrl,
+  testnet: testnetUrl,
   devnet: "",
-    local: "http://localhost:30731",
-    mevmdevnet: "",
-    custom: "",
-  };
+  local: "http://localhost:30731",
+  mevmdevnet: "",
+  custom: "",
+};
 
 export const availableNetworks = ["mainnet", "testnet"];
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -9,21 +9,21 @@ const prefix = import.meta.env.REACT_APP_PREFIX || "";
 export const mainnetUrl =
   import.meta.env.MAINNET_URL || `https://mainnet.movementnetwork.xyz/v1`;
 
-export const bardockTestnetUrl =
+export const testnetUrl =
   import.meta.env.MOVEMENT_TESTNET_URL ||
   `https://testnet.movementnetwork.xyz/v1`;
 
   export const networks = {
     mainnet: mainnetUrl,
     testnet: "",
-    "bardock testnet": bardockTestnetUrl,
+    "testnet": testnetUrl,
   devnet: "",
     local: "http://localhost:30731",
     mevmdevnet: "",
     custom: "",
   };
 
-export const availableNetworks = ["mainnet", "bardock testnet"];
+export const availableNetworks = ["mainnet", "testnet"];
 
 export type NetworkName = keyof typeof networks;
 
@@ -36,7 +36,6 @@ type ApiKeys = {
  */
 const apiKeys: ApiKeys = {
   mainnet: undefined,
-  "bardock testnet": undefined,
   testnet: undefined,
   devnet: undefined,
   local: undefined,
@@ -54,7 +53,6 @@ export function isValidNetworkName(value: string): value is NetworkName {
 
 export enum Network {
   MAINNET = "mainnet",
-  BARDOCK_TESTNET = "bardock-testnet",
   TESTNET = "testnet",
   DEVNET = "devnet",
   LOCAL = "local",

--- a/src/global-config/network-selection.ts
+++ b/src/global-config/network-selection.ts
@@ -64,12 +64,6 @@ export function useNetworkSelector() {
     () => {
       const currentNetworkSearchParam = searchParams.get("network");
 
-      // Redirect testnet to testnet (testnet is valid but has no URL)
-      if (currentNetworkSearchParam === "testnet") {
-        selectNetwork("testnet", {replace: true});
-        return;
-      }
-
       // Check if network is valid AND has a URL (not empty)
       if (
         !isValidNetworkName(currentNetworkSearchParam ?? "") ||

--- a/src/global-config/network-selection.ts
+++ b/src/global-config/network-selection.ts
@@ -64,9 +64,9 @@ export function useNetworkSelector() {
     () => {
       const currentNetworkSearchParam = searchParams.get("network");
 
-      // Redirect testnet to bardock testnet (testnet is valid but has no URL)
+      // Redirect testnet to testnet (testnet is valid but has no URL)
       if (currentNetworkSearchParam === "testnet") {
-        selectNetwork("bardock testnet", {replace: true});
+        selectNetwork("testnet", {replace: true});
         return;
       }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,19 @@ initGTM({
 
 ReactGA.initialize(import.meta.env.GA_TRACKING_ID || "G-VS7KJG61TM");
 
+// Rewrite legacy "bardock testnet" network param to "testnet" before React boots.
+{
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("network") === "bardock testnet") {
+    params.set("network", "testnet");
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}?${params.toString()}${window.location.hash}`,
+    );
+  }
+}
+
 // TODO: redirect to the new explorer domain on the domain host
 // if (window.location.origin.includes("explorer.testnet.suzuka.movementlabs.xyz")) {
 //   const new_location = window.location.href.replace(

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -41,11 +41,9 @@ export const getCustomParameters = () => {
 
 export const getDisplayNetworkName = (networkName: string): string => {
   if (networkName === "testnet") {
-    return "porto testnet";
-  } else if (networkName === "bardockTestnet") {
-    return "bardock testnet";
+    return "testnet";
   } else if (networkName === "mainnet") {
-    return "mainnet beta";
+    return "mainnet";
   }
   return networkName;
 };

--- a/src/pages/layout/NetworkSelect.tsx
+++ b/src/pages/layout/NetworkSelect.tsx
@@ -39,15 +39,6 @@ export const getCustomParameters = () => {
   };
 };
 
-export const getDisplayNetworkName = (networkName: string): string => {
-  if (networkName === "testnet") {
-    return "testnet";
-  } else if (networkName === "mainnet") {
-    return "mainnet";
-  }
-  return networkName;
-};
-
 function NetworkAndChainIdCached({
   networkName,
   chainId,
@@ -66,7 +57,7 @@ function NetworkAndChainIdCached({
       width="100%"
       paddingY={0.75}
     >
-      <Typography>{getDisplayNetworkName(networkName)}</Typography>
+      <Typography>{networkName}</Typography>
       <Typography variant="body2" sx={{color: theme.palette.text.disabled}}>
         {chainId}
       </Typography>
@@ -158,7 +149,7 @@ export default function NetworkSelect() {
           value={state.network_name}
           onChange={handleChange}
           renderValue={(value) => (
-            <Typography>{getDisplayNetworkName(value)}</Typography>
+            <Typography>{value}</Typography>
           )}
           onClose={() => {
             setTimeout(() => {

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -130,7 +130,7 @@ function NetworkStatusWrapper({children}: LayoutProps) {
   
   return (
     <>
-      <NetworkStatus componentName={state.network_name === "mainnet" ? "MAINNET BETA" : "BARDOCK TESTNET"} />
+      <NetworkStatus componentName={state.network_name === "mainnet" ? "MAINNET" : "TESTNET"} />
       {children}
     </>
   );


### PR DESCRIPTION
## Summary

- Renamed the "Mainnet Beta" network label to **Mainnet** across the UI.
- Renamed the "Bardock Testnet" network (key `bardock testnet`) to **Testnet** across constants, hooks, and the network selector. Analytics/GraphQL endpoint constants follow suit (`BARDOCK_ANALYTICS_DATA_URL` → `TESTNET_ANALYTICS_DATA_URL`, `BARDOCK_GRAPHQL` → `TESTNET_GRAPHQL`).
- Removed the leftover commented-out Porto testnet GraphQL branch from `getGraphqlURI`.
- Added a pre-React redirect in `src/index.tsx` that rewrites `?network=bardock+testnet` to `?network=testnet` via `history.replaceState` before the app reads the param, so old links don't fall through to mainnet. Removed the now-dead self-redirect stub in `network-selection.ts`.

## Test plan

- [x] Visit `/?network=bardock+testnet` — URL rewrites to `?network=testnet` and the Testnet network loads.
- [x] Visit `/?network=testnet` directly — loads Testnet, no redirect loop, no extra history entry.
- [x] Visit `/?network=mainnet` and `/` (no param) — Mainnet loads, header label reads "Mainnet" (not "Mainnet Beta").
- [x] Confirm the network dropdown lists "Mainnet" and "Testnet" only.
- [ ] Confirm analytics charts and TPS load on both Mainnet and Testnet (uses the renamed `TESTNET_ANALYTICS_DATA_URL`).
- [x] Confirm GraphQL-backed views work on Testnet (uses `TESTNET_GRAPHQL` / hasura.testnet endpoint).
